### PR TITLE
feat: add warning when code fence has no lang

### DIFF
--- a/autoload/textobj/markdown/chunk.vim
+++ b/autoload/textobj/markdown/chunk.vim
@@ -2,42 +2,52 @@
 function! textobj#markdown#chunk#af()
   let l:tail = search('```$', 'Wc')
   let l:head = search('```\S', 'Wb')
-  return !l:head || !l:tail
-        \ ? 0
-        \ : ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
+  if !l:head || !l:tail
+    echom "vim-textob-markdown: Code fence not found, perhaps the start does not identify a language"
+    return 0
+  endif
+  return ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
 endfunction
 
 function! textobj#markdown#chunk#if()
   let l:tail = search('```$', 'Wc')
   let l:head = search('```\S', 'Wb')
   if !l:head || !l:tail
+    echom "vim-textob-markdown: Code fence not found, perhaps the start does not identify a language"
     return 0
   endif
   let l:head += 1
   let l:tail -= 1
-  return l:tail < l:head
-        \ ? 0
-        \ : ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
+  if l:tail < l:head
+    echom "vim-textob-markdown: Code fence found, but zero length"
+    return 0
+  endif
+  return ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
 endfunction
 
 " backward chunk
 function! textobj#markdown#chunk#aF()
   let l:head = search('```\S', 'Wbc')
   let l:tail = search('```$', 'W')
-  return !l:head || !l:tail
-        \ ? 0
-        \ : ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
+  if !l:head || !l:tail
+    echom "vim-textob-markdown: Code fence not found, perhaps the start does not identify a language"
+    return 0
+  endif
+  return ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
 endfunction
 
 function! textobj#markdown#chunk#iF()
   let l:head = search('```\S', 'Wbc')
   let l:tail = search('```$', 'W')
   if !l:head || !l:tail
+    echom "vim-textob-markdown: Code fence not found, perhaps the start does not identify a language"
     return 0
   endif
   let l:head += 1
   let l:tail -= 1
-  return l:tail < l:head
-        \ ? 0
-        \ : ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
+  if l:tail < l:head
+    echom "vim-textob-markdown: Code fence found, but zero length"
+    return 0
+  endif
+  return ['V', [0, l:head, 1, 0], [0, l:tail, 1, 0]]
 endfunction


### PR DESCRIPTION
I spent some time trying to make your plugin work this morning.

Found out that it doesn't work when the code fence does not include a language.

Thinking about it I can see how it's good practice to document the language and it makes identification of start / end easier.

However if the plugin gave me more of a clue why it was doing nothing, I might have saved some time.

This PR gives users more of a clue when it goes wrong.