### PR TITLE
Fix variable name for disabling default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ mappings, simply include the following in you `vimrc/init.vim`:
 
 ```vim
 " remove default mappings
-let g:__textobj_markdown_no_mappings=1
+let g:textobj_markdown_no_default_key_mappings=1
 ```
 
 Headers


### PR DESCRIPTION
Perhaps this was changed in vim-textobj-user since the plugin was written? Now the required variable name is `g:textobj_{plugin}_no_default_key_mappings`.